### PR TITLE
创建了dockerfile文件，增加了生成docker镜像文件的支持

### DIFF
--- a/api/dockerfile
+++ b/api/dockerfile
@@ -1,0 +1,16 @@
+ENV ASPNETCORE_ENVIRONMENT=Production
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /app
+#FROM mcr.microsoft.com/dotnet/sdk:7.0-buster AS build
+WORKDIR /src
+COPY ["SimpleAdmin/","SimpleAdmin/"]
+WORKDIR "/src/SimpleAdmin"
+FROM build AS publish
+RUN dotnet publish "SimpleAdmin.Web.Entry/SimpleAdmin.Web.Entry.csproj" --framework net7.0 -c Release -o /app/publish
+
+# 最后 使用7.0作为运行环境
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "SimpleAdmin.Web.Entry.dll"]


### PR DESCRIPTION
在api路径下使用下面命令生成镜像文件
docker build ./
或
docker build -t dotnetbackend:v1 ./
dotnetbackend:v1为标签和版本信息